### PR TITLE
Infra/add sync wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Once you have an instance of `ArmisSdk`, you can start interacting with the vari
 
 > [!NOTE]
 > Note that all functions in this SDK that eventually make HTTP requests are asynchronous.
+> 
+> However, for convenience, all public asynchronous functions can also be executed in a synchronous way. 
 
 For example, if you want to update a site's location:
 ```python

--- a/armis_sdk/clients/network_equipment_client.py
+++ b/armis_sdk/clients/network_equipment_client.py
@@ -1,6 +1,7 @@
 from typing import List
 from typing import Set
 
+import universalasync
 from httpx import HTTPStatusError
 
 from armis_sdk.core import response_utils
@@ -10,6 +11,7 @@ from armis_sdk.core.base_entity_client import BaseEntityClient
 from armis_sdk.entities.site import Site
 
 
+@universalasync.wrap
 class NetworkEquipmentClient(
     BaseEntityClient
 ):  # pylint: disable=too-few-public-methods

--- a/armis_sdk/clients/site_integrations_client.py
+++ b/armis_sdk/clients/site_integrations_client.py
@@ -1,6 +1,7 @@
 from typing import List
 from typing import Set
 
+import universalasync
 from httpx import HTTPStatusError
 
 from armis_sdk.core import response_utils
@@ -10,6 +11,7 @@ from armis_sdk.core.base_entity_client import BaseEntityClient
 from armis_sdk.entities.site import Site
 
 
+@universalasync.wrap
 class SiteIntegrationsClient(
     BaseEntityClient
 ):  # pylint: disable=too-few-public-methods

--- a/armis_sdk/clients/sites_client.py
+++ b/armis_sdk/clients/sites_client.py
@@ -1,6 +1,8 @@
 from typing import AsyncIterator
 from typing import List
 
+import universalasync
+
 from armis_sdk.clients.network_equipment_client import NetworkEquipmentClient
 from armis_sdk.clients.site_integrations_client import SiteIntegrationsClient
 from armis_sdk.core import response_utils
@@ -9,6 +11,7 @@ from armis_sdk.core.base_entity_client import BaseEntityClient
 from armis_sdk.entities.site import Site
 
 
+@universalasync.wrap
 class SitesClient(BaseEntityClient):
     # pylint: disable=line-too-long
     """
@@ -178,7 +181,7 @@ class SitesClient(BaseEntityClient):
             ]
             ```
         """
-        id_to_site = {site.id: site async for site in await self.list()}
+        id_to_site = {site.id: site async for site in self.list()}
         root = []
         for site in id_to_site.values():
             if parent := id_to_site.get(site.parent_id):
@@ -204,7 +207,7 @@ class SitesClient(BaseEntityClient):
 
             async def main():
                 sites_client = SitesClient()
-                async for site in await sites_client.list()
+                async for site in sites_client.list()
                     print(site)
 
             asyncio.run(main())
@@ -215,7 +218,8 @@ class SitesClient(BaseEntityClient):
             Site(id=2)
             ```
         """
-        return self._list("/api/v1/sites/", "sites", Site)
+        async for item in self._list("/api/v1/sites/", "sites", Site):
+            yield item
 
     async def update(self, site: Site):
         """Update a site's properties.

--- a/armis_sdk/core/armis_client.py
+++ b/armis_sdk/core/armis_client.py
@@ -6,6 +6,7 @@ from typing import Optional
 from typing import TypeVar
 
 import httpx
+import universalasync
 
 from armis_sdk.core import response_utils
 from armis_sdk.core.armis_auth import ArmisAuth
@@ -29,6 +30,7 @@ USER_AGENT_PARTS = [
 DataTypeT = TypeVar("DataTypeT", dict, list)
 
 
+@universalasync.wrap
 class ArmisClient:  # pylint: disable=too-few-public-methods
     """
     A class that provides easy access to the Armis API, taking care of authenticating requests.

--- a/armis_sdk/core/armis_sdk.py
+++ b/armis_sdk/core/armis_sdk.py
@@ -27,7 +27,7 @@ class ArmisSdk:  # pylint: disable=too-few-public-methods
         armis_sdk = ArmisSdk()
 
         async def main():
-            async for site in await armis_sdk.sites.list():
+            async for site in armis_sdk.sites.list():
                 print(site)
 
         asyncio.run(main())

--- a/armis_sdk/core/base_entity_client.py
+++ b/armis_sdk/core/base_entity_client.py
@@ -2,6 +2,8 @@ from typing import AsyncIterator
 from typing import Optional
 from typing import Type
 
+import universalasync
+
 from armis_sdk.core.armis_client import ArmisClient
 from armis_sdk.core.base_entity import BaseEntityT
 
@@ -11,6 +13,7 @@ class BaseEntityClient:  # pylint: disable=too-few-public-methods
     def __init__(self, armis_client: Optional[ArmisClient] = None) -> None:
         self._armis_client = armis_client or ArmisClient()
 
+    @universalasync.async_to_sync_wraps
     async def _list(
         self, url: str, key: str, model: Type[BaseEntityT]
     ) -> AsyncIterator[BaseEntityT]:

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,6 +46,8 @@ you can start interacting with the various clients, each handles use-cases of a 
 
     Note that all functions in this SDK that eventually make HTTP requests are asynchronous.
 
+    However, for convenience, all public asynchronous functions can also be executed in a synchronous way.
+
 
 For example, if you want to update a site's location:
 ```python linenums="1" hl_lines="10"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1393,6 +1393,18 @@ files = [
 markers = {docs = "python_version < \"3.11\""}
 
 [[package]]
+name = "universalasync"
+version = "0.4.0.1"
+description = "A library to help automate the creation of universal python libraries"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "universalasync-0.4.0.1-py3-none-any.whl", hash = "sha256:55691b23f8265ff9a658d5eaee5a0375d75ac46432862198178c9a360062ba52"},
+    {file = "universalasync-0.4.0.1.tar.gz", hash = "sha256:aadf1f20170366b76fb0317a343775c403842c8db25062f7d68184a09b3e882c"},
+]
+
+[[package]]
 name = "urllib3"
 version = "2.3.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
@@ -1477,4 +1489,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9"
-content-hash = "f7fca603cd63a9079930d02219c221101f1aceaad0be7876b841f1ef4ee9a502"
+content-hash = "e55a0ae5b2c733cb6799e26dc6987e31a189d188a5528121add45d7cb893c0fd"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ plugins = ['pydantic.mypy']
 [tool.poetry.dependencies]
 pydantic = "^2.10.5"
 httpx = "^0.28.1"
+universalasync = "^0.4.0.1"
 
 [tool.poetry.group.dev.dependencies]
 black = "^24.10.0"

--- a/tests/armis_sdk/clients/sites_client_test.py
+++ b/tests/armis_sdk/clients/sites_client_test.py
@@ -231,7 +231,7 @@ async def test_list_sites(from_response, expected, httpx_mock: pytest_httpx.HTTP
     )
 
     sites_client = SitesClient()
-    sites = [site async for site in await sites_client.list()]
+    sites = [site async for site in sites_client.list()]
 
     assert sites == [expected]
 
@@ -280,7 +280,7 @@ async def test_list_sites_with_multiple_pages(
     )
 
     sites_client = SitesClient()
-    sites = [site async for site in await sites_client.list()]
+    sites = [site async for site in sites_client.list()]
 
     assert sites == [
         Site(id=1, name="mock_site_1"),


### PR DESCRIPTION
Use [universalasync](https://github.com/bitcart/universalasync) to wrap all async functions in a wrapper that allows to run them both sync and async.

Please note that for this to work properly, I had to change the implementation of `async def list` a bit, so now usage is
```
async for s in armis_sdk.sites.list():
    print(s.id, s.name)
```
instead of
```
async for s in await armis_sdk.sites.list():
    print(s.id, s.name)
```